### PR TITLE
Feature/add separate parameter steps to tutorial

### DIFF
--- a/.tutorial-rust/03-life-cycle.md
+++ b/.tutorial-rust/03-life-cycle.md
@@ -106,17 +106,26 @@ Now your plugin can do stuff!
 If you click on [`rust-plugin/src/main.rs`](/home/runner/Writing-Your-First-CLN-Plugin/rust-plugin/src/main.rs) in the file tree to your left, you will see a basic CLN plugin written in Rust. It doesn't do much, yet. It pretty much just runs. We'll add more to it as we work through this tutorial.
 
 Here it is:
-```py
-#!/usr/bin/env python3
-from pyln.client import Plugin # We import `Plugin` from the `pyln-client` pip package, which does all the hard work for us
+```rust
+#[macro_use]
+extern crate serde_json;
+use anyhow::anyhow;
+use cln_plugin::{options, Builder, Error, Plugin};
+use tokio;
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let state = ();
 
-plugin = Plugin() # This is our plugin's handle
-
-@plugin.init() # Decorator to define a callback once the `init` method call has successfully completed
-def init(options, configuration, plugin, **kwargs):
-    plugin.log("Plugin helloworld.py initialized")
-
-plugin.run() # Run our plugin
+    if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
+        .dynamic()
+        .start(state)
+        .await?
+    {
+        plugin.join().await
+    } else {
+        Ok(())
+    }
+}
 ```
 
 To test, open a shell and enter the following commands:

--- a/.tutorial-rust/03-life-cycle.md
+++ b/.tutorial-rust/03-life-cycle.md
@@ -107,6 +107,8 @@ If you click on [`rust-plugin/src/main.rs`](/home/runner/Writing-Your-First-CLN-
 
 Here it is:
 ```rust
+//! This is a test plugin used to verify that we can compile and run
+//! plugins using the Rust API against Core Lightning.
 #[macro_use]
 extern crate serde_json;
 use anyhow::anyhow;

--- a/.tutorial-rust/04-rpc-methods.md
+++ b/.tutorial-rust/04-rpc-methods.md
@@ -52,10 +52,15 @@ l1-cli testmethod
 ```
 
 Now, lets use the `serde_json::value` parameter which allows us to pass arguments.
+Create a new method `testmethod_argument` and register it in your main() function.
 Change `_v` to `v` as it is no longer an unused parameter.
 
 ```rust
-async fn testmethod(p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
+.rpcmethod("testmethod_argument", "This is a test", testmethod_argument)
+```
+
+```rust
+async fn testmethod_argument(p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
   Ok(json!(format!("Hello {}", v)))
 }
 ```
@@ -63,7 +68,7 @@ async fn testmethod(p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::V
 Try it with an argument:
 
 ```
-l1-cli testmethod <your name>
+l1-cli testmethod_argument <your name>
 ```
 
 - [ ] Add an RPC method

--- a/.tutorial-rust/04-rpc-methods.md
+++ b/.tutorial-rust/04-rpc-methods.md
@@ -51,16 +51,19 @@ Now invoke your new RPC method:
 l1-cli testmethod
 ```
 
+Now, lets use the `serde_json::value` parameter which allows us to pass arguments.
+Change `_v` to `v` as it is no longer an unused parameter.
+
+```rust
+async fn testmethod(p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
+  Ok(json!(format!("Hello {}", v)))
+}
+```
+
 Try it with an argument:
 
 ```
 l1-cli testmethod <your name>
-```
-
-Try causing the rpc call to throw an error:
-
-```
-l1-cli testmethod too many arguments
 ```
 
 - [ ] Add an RPC method

--- a/.tutorial-rust/04-rpc-methods.md
+++ b/.tutorial-rust/04-rpc-methods.md
@@ -51,7 +51,7 @@ Now invoke your new RPC method:
 l1-cli testmethod
 ```
 
-Now, lets use the `serde_json::value` parameter which allows us to pass arguments.
+Now, let's use the `serde_json::Value` parameter which allows us to pass arguments.
 Create a new method `testmethod_argument` and register it in your main() function.
 Change `_v` to `v` as it is no longer an unused parameter.
 
@@ -72,8 +72,8 @@ l1-cli testmethod_argument <your name>
 ```
 
 The v argument is passed to our RPC method as json.
-Parsing the string and printing just the string is left as an exercise to the reader.
-Bonus is to print an error if more than 1 argument is passed.
+Parsing and printing just the string (properly formatted, without escape characters) is left as an exercise to the reader.
+As a bonus exercise, print an error if more than 1 argument is passed.
 
 - [ ] Add an RPC method
 - [ ] Test that it works as expected

--- a/.tutorial-rust/04-rpc-methods.md
+++ b/.tutorial-rust/04-rpc-methods.md
@@ -71,5 +71,9 @@ Try it with an argument:
 l1-cli testmethod_argument <your name>
 ```
 
+The v argument is passed to our RPC method as json.
+Parsing the string and printing just the string is left as an exercise to the reader.
+Bonus is to print an error if more than 1 argument is passed.
+
 - [ ] Add an RPC method
 - [ ] Test that it works as expected

--- a/.tutorial-rust/05-options.md
+++ b/.tutorial-rust/05-options.md
@@ -19,21 +19,14 @@ Add this code to your `main.rs` file (hint: insert this before `.dynamic()`):
 ))
 ```
 
-Next, edit your `testmethod` RPC method from the previous step to use your
-option in that call:
-
-Change your rpc handler `testmethod` from:
+Next, add a new method `testmethod_option` RPC method to use your option in that call.
 
 ```rust
-async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
-    Ok(json!("Hello"))
-}
+.rpcmethod("testmethod_option", "This is a test", testmethod_option)
 ```
 
-To look like:
-
 ```rust
-async fn testmethod(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn testmethod_option(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     Ok(json!(format!("Hello, {:?}", p.option("name").unwrap())))
 }
 ```
@@ -61,10 +54,10 @@ Now start your plugin, inserting a value for your new option:
 l1-cli -k plugin subcommand=start plugin=$(pwd)/target/debug/rust-plugin name='<insert name here>'
 ```
 
-Now invoke the updated `testmethod` RPC method:
+Now invoke the new `testmethod_option` RPC method:
 
 ```sh
-l1-cli testmethod
+l1-cli testmethod_option
 ```
 
 Try it with various arguments, and see what happens.

--- a/rust-plugin/src/main.rs
+++ b/rust-plugin/src/main.rs
@@ -10,24 +10,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let state = ();
 
     if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
-        .option(options::ConfigOption::new(
-            "test-option",
-            options::Value::Integer(42),
-            "a test-option with default 42",
-        ))
-        .option(options::ConfigOption::new(
-            "opt-option",
-            options::Value::OptInteger,
-            "An optional option",
-        ))
-        .rpcmethod("testmethod", "This is a test", testmethod)
-        .rpcmethod(
-            "testoptions",
-            "Retrieve options from this plugin",
-            testoptions,
-        )
-        .subscribe("connect", connect_handler)
-        .hook("peer_connected", peer_connected_handler)
         .dynamic()
         .start(state)
         .await?
@@ -36,27 +18,4 @@ async fn main() -> Result<(), anyhow::Error> {
     } else {
         Ok(())
     }
-}
-
-async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
-    Ok(json!({
-        "opt-option": format!("{:?}", p.option("opt-option").unwrap())
-    }))
-}
-
-async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
-    Ok(json!("Hello"))
-}
-
-async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
-    log::info!("Got a connect notification: {}", v);
-    Ok(())
-}
-
-async fn peer_connected_handler(
-    _p: Plugin<()>,
-    v: serde_json::Value,
-) -> Result<serde_json::Value, Error> {
-    log::info!("Got a connect hook call: {}", v);
-    Ok(json!({"result": "continue"}))
 }

--- a/rust-plugin/src/main_complete.rs
+++ b/rust-plugin/src/main_complete.rs
@@ -13,6 +13,7 @@ async fn main() -> Result<(), anyhow::Error> {
     if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
         .rpcmethod("testmethod", "This is a test", testmethod)
         .rpcmethod("testmethod_argument", "This is a test", testmethod_argument)
+        .rpcmethod("testmethod_argument_bonus", "This is a test", testmethod_argument_bonus)
         .option(options::ConfigOption::new(
             "name",
             options::Value::String("World".to_string()),
@@ -28,12 +29,6 @@ async fn main() -> Result<(), anyhow::Error> {
     } else {
         Ok(())
     }
-}
-
-async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
-    Ok(json!({
-        "opt-option": format!("{:?}", p.option("opt-option").unwrap())
-    }))
 }
 
 async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
@@ -61,7 +56,7 @@ async fn peer_connected_handler(
     Ok(json!({"result": "continue"}))
 }
 
-async fn testmethod(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+async fn testmethod_argument_bonus(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     let name_value = p
         .option("name")
         .unwrap_or_else(|| options::Value::String("Unknown".to_string()));

--- a/rust-plugin/src/main_complete.rs
+++ b/rust-plugin/src/main_complete.rs
@@ -29,6 +29,30 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 }
 
+async fn testoptions(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+    Ok(json!({
+        "opt-option": format!("{:?}", p.option("opt-option").unwrap())
+    }))
+}
+
+async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+    Ok(json!("Hello"))
+}
+
+async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
+    log::info!("Got a connect notification: {}", v);
+    Ok(())
+}
+
+async fn peer_connected_handler(
+    _p: Plugin<()>,
+    v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
+    log::info!("Got a connect hook call: {}", v);
+    Ok(json!({"result": "continue"}))
+}
+
+
 async fn testmethod(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     let name_value = p
         .option("name")

--- a/rust-plugin/src/main_complete.rs
+++ b/rust-plugin/src/main_complete.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     if let Some(plugin) = Builder::new(tokio::io::stdin(), tokio::io::stdout())
         .rpcmethod("testmethod", "This is a test", testmethod)
+        .rpcmethod("testmethod_argument", "This is a test", testmethod_argument)
         .option(options::ConfigOption::new(
             "name",
             options::Value::String("World".to_string()),
@@ -39,6 +40,14 @@ async fn testmethod(_p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json:
     Ok(json!("Hello"))
 }
 
+async fn testmethod_argument(p: Plugin<()>, v: serde_json::Value) -> Result<serde_json::Value, Error> {
+  Ok(json!(format!("Hello, {}", v)))
+}
+
+async fn testmethod_option(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
+    Ok(json!(format!("Hello, {:?}", p.option("name").unwrap())))
+}
+
 async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
     log::info!("Got a connect notification: {}", v);
     Ok(())
@@ -52,7 +61,6 @@ async fn peer_connected_handler(
     Ok(json!({"result": "continue"}))
 }
 
-
 async fn testmethod(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::Value, Error> {
     let name_value = p
         .option("name")
@@ -62,11 +70,6 @@ async fn testmethod(p: Plugin<()>, _v: serde_json::Value) -> Result<serde_json::
     } else {
         Err(anyhow!("Expected a string for 'name' option".to_string())) // Adjust the error type and message as needed
     }
-}
-
-async fn connect_handler(_p: Plugin<()>, v: serde_json::Value) -> Result<(), Error> {
-    log::info!("Got a connect notification: {}", v);
-    Ok(())
 }
 
 async fn on_htlc_accepted(


### PR DESCRIPTION
Update 03-life-cycle.md python code to be the rust plugin code in the rust tutorial
Add parameter passing tutorial step
Remove too many arguments step
Add missing top header to rust 03-life-cycle.md
Refactor option step to testmethod_option
Refactor parameter step to testmethod_argument