### PR TITLE
Update forking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Here are the links to fork the project:
 
 1. **Log in** to your Replit account.
 2. Click on one of the links above to open the project.
-3. Once the Repl opens, look for the "Fork" button at the top-right corner of the page.
-4. **Click on "Fork"** to copy the Repl to your own account.
+3. Once the Repl opens, look for the "Remix this app" button at the left half of the page.
+4. **Click on "Remix this app"** to copy the Repl to your own account.
 5. After forking, you will see the project in your Replit workspace, and you can start editing it.
 
 Now that you've forked the Repl, you can follow the instructions in the project to start building your own CLN plugin!


### PR DESCRIPTION
Replit updated their interface, now there's a "Remix this app" button on the left half of the page instead of a "Fork" button, which can be confusing.

This is the new Replit screen:
<img width="450" alt="Screenshot 2025-02-12 at 16 58 18" src="https://github.com/user-attachments/assets/3772f684-b4ec-4a73-9fe1-7b19aa82a04f" />
